### PR TITLE
Fix list item delete overrides

### DIFF
--- a/lerna/_internal/config_loader_impl.py
+++ b/lerna/_internal/config_loader_impl.py
@@ -5,9 +5,9 @@ import re
 import sys
 import warnings
 from textwrap import dedent
-from typing import Any, List, MutableSequence, Optional, Tuple
+from typing import Any, List, MutableSequence, Optional, Tuple, Union
 
-from omegaconf import Container, DictConfig, OmegaConf, flag_override, open_dict
+from omegaconf import Container, DictConfig, ListConfig, OmegaConf, flag_override, open_dict
 from omegaconf.errors import (
     ConfigAttributeError,
     ConfigKeyError,
@@ -336,7 +336,10 @@ class ConfigLoaderImpl(ConfigLoader):
                             del cfg[key]
                         else:
                             node = OmegaConf.select(cfg, key[0:last_dot])
-                            del node[key[last_dot + 1 :]]
+                            node_key: Union[str, int] = key[last_dot + 1 :]
+                            if isinstance(node, ListConfig):
+                                node_key = int(node_key)
+                            del node[node_key]
 
                 elif override.is_add():
                     if OmegaConf.select(cfg, key, throw_on_missing=False) is None or isinstance(value, (dict, list)):

--- a/lerna/tests/test_config_loader.py
+++ b/lerna/tests/test_config_loader.py
@@ -634,6 +634,8 @@ def test_complex_defaults(overrides: Any, expected: Any) -> None:
         param({"x": {"y": 10}}, ["~x.y=10"], {"x": {}}, id="delete_strict"),
         param({"x": [1, 2, 3]}, ["~x"], {}, id="delete:list"),
         param({"x": [1, 2, 3]}, ["~x=[1,2,3]"], {}, id="delete:list"),
+        param({"x": [1, 2, 3]}, ["~x.0"], {"x": [2, 3]}, id="delete:list_item"),
+        param({"x": [1, 2, 3]}, ["~x.1"], {"x": [1, 3]}, id="delete:list_item_middle"),
         param(
             {"x": 20},
             ["~z"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,9 @@ default-section = "third-party"
 known-first-party = [
     "lerna",
 ]
+known-third-party = [
+    "hydra",
+]
 section-order = [
     "future",
     "standard-library",


### PR DESCRIPTION
Port Hydra upstream change 6e489a92ce (https://github.com/facebookresearch/hydra/pull/3146) for deleting ListConfig items by index via CLI override.

- Cast nested delete keys to int when deleting from ListConfig parents.
- Add regression coverage for ~x.0 and ~x.1 overrides.
- Include staged notebook import formatting update.
